### PR TITLE
Field Assertion for Creation Rules and Update Rules

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -1,15 +1,15 @@
 # Fields
 
-* [Testing Fields on Components](#testing-fields-on-components)
-* [Testing Fields Individually](#testing-fields-individually)
+-   [Testing Fields on Components](#testing-fields-on-components)
+-   [Testing Fields Individually](#testing-fields-individually)
 
 ## Testing Fields on Components
 
 Field assertions can be run on the following Nova classes:
 
-* [Actions](actions.md#testing-actions)
-* [Lenses](lenses.md#testing-lenses)
-* [Resources](resources.md#testing-resources)
+-   [Actions](actions.md#testing-actions)
+-   [Lenses](lenses.md#testing-lenses)
+-   [Resources](resources.md#testing-resources)
 
 ### `assertHasField($field)`
 
@@ -66,7 +66,40 @@ Asserts that the following rule is being applied to the value of this field. Thi
 ```php
 $field->assertRuleMissing('required');
 ```
+
 Asserts that the following rule is not being applied to the value of this field. This assertion only works on string-type rules, not closures.
+
+### `assertHasCreationRule($rule)`
+
+```php
+$field->assertHasCreationRule('required');
+```
+
+Asserts that the following rule is being applied to the value of this field when a resource is created. This assertion only works on string-type rules, not closures.
+
+### `assertCreationRuleMissing($rule)`
+
+```php
+$field->assertCreationRuleMissing('required');
+```
+
+Asserts that the following rule is not being applied to the value of this field when a resource is created. This assertion only works on string-type rules, not closures.
+
+### `assertHasUpdateRule($rule)`
+
+```php
+$field->assertHasUpdateRule('required');
+```
+
+Asserts that the following rule is being applied to the value of this field when a resource is updated. This assertion only works on string-type rules, not closures.
+
+### `assertUpdateRuleMissing($rule)`
+
+```php
+$field->assertUpdateRuleMissing('required');
+```
+
+Asserts that the following rule is not being applied to the value of this field when a resource is updated. This assertion only works on string-type rules, not closures.
 
 ### `assertShownOnIndex()`
 

--- a/src/Fields/MockFieldElement.php
+++ b/src/Fields/MockFieldElement.php
@@ -43,6 +43,66 @@ class MockFieldElement
     }
 
     /**
+     * Assert that the following rule can be found on the field when a
+     * resource being created.
+     *
+     * @param string $rule The rule to match this field against
+     * @param string $message
+     * @return $this
+     */
+    public function assertHasCreationRule(string $rule, string $message = ''): self
+    {
+        PHPUnit::assertContains($rule, $this->field->creationRules, $message);
+
+        return $this;
+    }
+
+    /**
+     * Assert that the following rule cannot be found on the field when a
+     * resource being created.
+     *
+     * @param string $rule The rule to match this field against
+     * @param string $message
+     * @return $this
+     */
+    public function assertCreationRuleMissing(string $rule, string $message = ''): self
+    {
+        PHPUnit::assertNotContains($rule, $this->field->creationRules, $message);
+
+        return $this;
+    }
+
+    /**
+     * Assert that the following rule can be found on the field when a
+     * resource being updated.
+     *
+     * @param string $rule The rule to match this field against
+     * @param string $message
+     * @return $this
+     */
+    public function assertHasUpdateRule(string $rule, string $message = ''): self
+    {
+        PHPUnit::assertContains($rule, $this->field->updateRules, $message);
+
+        return $this;
+    }
+
+    /**
+     * Assert that the following rule cannot be found on the field when a
+     * resource being created.
+     *
+     * @param string $rule The rule to match this field against
+     * @param string $message
+     * @return $this
+     */
+    public function assertUpdateRuleMissing(string $rule, string $message = ''): self
+    {
+        PHPUnit::assertNotContains($rule, $this->field->updateRules, $message);
+
+        return $this;
+    }
+
+    /**
      * Assert that the field can be shown on the index view.
      *
      * @param string $message

--- a/tests/Feature/Fields/MockFieldElementTest.php
+++ b/tests/Feature/Fields/MockFieldElementTest.php
@@ -43,6 +43,58 @@ class MockFieldElementTest extends TestCase
 
     // endregion
 
+    // region assertHasCreationRule
+    public function testItSucceedsIfFieldHasTheSpecifiedCreationRule()
+    {
+        $this->mock->field('Epsilon')->assertHasCreationRule('min:8');
+    }
+
+    public function testItFailsIfFieldDoesNotHaveTheSpecifiedCreationRule()
+    {
+        $this->shouldFail()->mock->field('Epsilon')->assertHasCreationRule('min:100');
+    }
+
+    // endregion
+
+    // region assertCreationRuleMissing
+    public function testItSucceedsIfSpecifiedCreationRuleMissingFromField()
+    {
+        $this->mock->field('Epsilon')->assertCreationRuleMissing('min:100');
+    }
+
+    public function testItFailsIfSpecifiedCreationRuleNotMissingFromField()
+    {
+        $this->shouldFail()->mock->field('Epsilon')->assertCreationRuleMissing('min:8');
+    }
+
+    // endregion
+
+    // region assertHasUpdateRule
+    public function testItSucceedsIfFieldHasTheSpecifiedUpdateRule()
+    {
+        $this->mock->field('Epsilon')->assertHasUpdateRule('min:16');
+    }
+
+    public function testItFailsIfFieldDoesNotHaveTheSpecifiedUpdateRule()
+    {
+        $this->shouldFail()->mock->field('Epsilon')->assertHasUpdateRule('min:100');
+    }
+
+    // endregion
+
+    // region assertUpdateRuleMissing
+    public function testItSucceedsIfSpecifiedUpdateRuleMissingFromField()
+    {
+        $this->mock->field('Epsilon')->assertUpdateRuleMissing('min:100');
+    }
+
+    public function testItFailsIfSpecifiedUpdateRuleNotMissingFromField()
+    {
+        $this->shouldFail()->mock->field('Epsilon')->assertUpdateRuleMissing('min:16');
+    }
+
+    // endregion
+
     // region assertShownOnIndex
     public function testItSucceedsIfFieldIsShownOnIndex()
     {

--- a/tests/Fixtures/Resources/ResourceForFieldTests.php
+++ b/tests/Fixtures/Resources/ResourceForFieldTests.php
@@ -25,6 +25,9 @@ class ResourceForFieldTests extends Resource
                 ->hideFromIndex()->hideFromDetail()->hideWhenCreating()->hideWhenUpdating(),
             Text::make('Delta', 'field_delta')
                 ->nullable()->sortable(),
+            Text::make('Epsilon', 'field_epsilon')
+                ->creationRules('min:8')
+                ->updateRules('min:16')
         ];
     }
 

--- a/tests/Fixtures/Resources/ResourceForFieldTests.php
+++ b/tests/Fixtures/Resources/ResourceForFieldTests.php
@@ -27,7 +27,7 @@ class ResourceForFieldTests extends Resource
                 ->nullable()->sortable(),
             Text::make('Epsilon', 'field_epsilon')
                 ->creationRules('min:8')
-                ->updateRules('min:16')
+                ->updateRules('min:16'),
         ];
     }
 


### PR DESCRIPTION
## What?
I've added assertion method to check for creation rules as well as update rules on a field.

## Why?
First of all, thank you for creating such a nice package that helps me very much to do unit testing in Nova. But yesterday, I just realized, there are fields that have different rule upon creation or updating. So for this case, using `assertHasRule` won't work. And that is the reason I come up with this new assertion method.

## How?
We can use the `creationRules` and `updateRules` attributes from the `Field` instance to check if it contains the given rule.

## Testing
I also have added the corresponding test for both creation rule assertion and update rule assertion.

## Final Notes
Hope this will help and sorry for my bad English :sweat_smile: .