### PR TITLE
Fix Laravel Nova 4 support

### DIFF
--- a/src/Traits/ActionAssertions.php
+++ b/src/Traits/ActionAssertions.php
@@ -2,11 +2,11 @@
 
 namespace JoshGaber\NovaUnit\Traits;
 
-use Illuminate\Http\Request;
 use JoshGaber\NovaUnit\Actions\ActionNotFoundException;
 use JoshGaber\NovaUnit\Actions\MockActionElement;
 use JoshGaber\NovaUnit\Constraints\ArrayHasInstanceOf;
 use Laravel\Nova\Actions\Action;
+use Laravel\Nova\Http\Requests\NovaRequest;
 use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Framework\Constraint\IsType;
 use PHPUnit\Framework\Constraint\TraversableContainsOnly;
@@ -23,7 +23,7 @@ trait ActionAssertions
     public function assertHasAction(string $action, string $message = ''): self
     {
         PHPUnit::assertThat(
-            $this->component->actions(Request::createFromGlobals()),
+            $this->component->actions(NovaRequest::createFromGlobals()),
             new ArrayHasInstanceOf($action),
             $message
         );
@@ -41,7 +41,7 @@ trait ActionAssertions
     public function assertActionMissing(string $action, string $message = ''): self
     {
         PHPUnit::assertThat(
-            $this->component->actions(Request::createFromGlobals()),
+            $this->component->actions(NovaRequest::createFromGlobals()),
             PHPUnit::logicalNot(new ArrayHasInstanceOf($action)),
             $message
         );
@@ -57,7 +57,7 @@ trait ActionAssertions
      */
     public function assertHasNoActions(string $message = ''): self
     {
-        PHPUnit::assertCount(0, $this->component->actions(Request::createFromGlobals()), $message);
+        PHPUnit::assertCount(0, $this->component->actions(NovaRequest::createFromGlobals()), $message);
 
         return $this;
     }
@@ -74,7 +74,7 @@ trait ActionAssertions
             $this->component->actions(Request::createFromGlobals()),
             PHPUnit::logicalAnd(
                 new IsType(IsType::TYPE_ARRAY),
-                new TraversableContainsOnly(Action::class, false)
+                new TraversableContainsOnly(NovaRequest::class, false)
             ),
             $message
         );
@@ -93,7 +93,7 @@ trait ActionAssertions
     public function action(string $actionType): MockActionElement
     {
         $actions = array_filter(
-            $this->component->actions(Request::createFromGlobals()),
+            $this->component->actions(NovaRequest::createFromGlobals()),
             fn ($a) => $a instanceof $actionType
         );
 

--- a/src/Traits/FilterAssertions.php
+++ b/src/Traits/FilterAssertions.php
@@ -5,6 +5,7 @@ namespace JoshGaber\NovaUnit\Traits;
 use Illuminate\Http\Request;
 use JoshGaber\NovaUnit\Constraints\ArrayHasInstanceOf;
 use Laravel\Nova\Filters\Filter;
+use Laravel\Nova\Http\Requests\NovaRequest;
 use PHPUnit\Framework\Assert as PHPUnit;
 use PHPUnit\Framework\Constraint\IsType;
 use PHPUnit\Framework\Constraint\TraversableContainsOnly;
@@ -21,7 +22,7 @@ trait FilterAssertions
     public function assertHasFilter(string $action, string $message = ''): self
     {
         PHPUnit::assertThat(
-            $this->component->filters(Request::createFromGlobals()),
+            $this->component->filters(NovaRequest::createFromGlobals()),
             new ArrayHasInstanceOf($action),
             $message
         );
@@ -39,7 +40,7 @@ trait FilterAssertions
     public function assertFilterMissing(string $action, string $message = ''): self
     {
         PHPUnit::assertThat(
-            $this->component->filters(Request::createFromGlobals()),
+            $this->component->filters(NovaRequest::createFromGlobals()),
             PHPUnit::logicalNot(new ArrayHasInstanceOf($action)),
             $message
         );
@@ -69,7 +70,7 @@ trait FilterAssertions
     public function assertHasValidFilters(string $message = ''): self
     {
         PHPUnit::assertThat(
-            $this->component->filters(Request::createFromGlobals()),
+            $this->component->filters(NovaRequest::createFromGlobals()),
             PHPUnit::logicalAnd(
                 new IsType(IsType::TYPE_ARRAY),
                 new TraversableContainsOnly(Filter::class, false)


### PR DESCRIPTION
Nova 4 has started using NovaRequest instead of request in `->actions()` and `->filters()`. All my tests were failing with :

``` 
App\Nova\Resources\ChangeApproval::actions(): Argument #1 ($request) must be of type Laravel\Nova\Http\Requests\NovaRequest, Illuminate\Http\Request given, called in /Users/nickp/Documents/GitHub/ixport.al/vendor/joshgaber/novaunit/src/Traits/ActionAssertions.php on line 26
```
