### PR TITLE
Add fields getter to MockAction

### DIFF
--- a/src/Actions/MockAction.php
+++ b/src/Actions/MockAction.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Collection;
 use JoshGaber\NovaUnit\MockComponent;
 use JoshGaber\NovaUnit\Traits\FieldAssertions;
 use Laravel\Nova\Fields\ActionFields;
+use Laravel\Nova\Http\Requests\NovaRequest;
 
 class MockAction extends MockComponent
 {
@@ -28,5 +29,10 @@ class MockAction extends MockComponent
                 $models instanceof Collection ? $models : collect(Arr::wrap($models))
             )
         );
+    }
+
+    public function getFields(): array
+    {
+        return $this->component->fields(NovaRequest::createFromGlobals());
     }
 }

--- a/tests/Feature/Actions/MockActionTest.php
+++ b/tests/Feature/Actions/MockActionTest.php
@@ -16,4 +16,11 @@ class MockActionTest extends TestCase
 
         $this->assertInstanceOf(MockActionResponse::class, $mockResult);
     }
+
+    public function testItReturnsMockActionFields()
+    {
+        $mockAction = new MockAction(new ActionValidFields());
+
+        $this->assertTrue(is_array($mockAction->getFields()));
+    }
 }


### PR DESCRIPTION
While the existing field assertions do bring coverage to the existence of of keys in the fields array on an Action, they still leave a couple of important gaps:

- Actions with `[]` no fields
- Any desired assertions about the values of the fields array.

The method added here affords a low-effort way to cover both of these cases by simply exposing the `fields` array via the `MockAction`. Let me know what you think.