### PR TITLE
Fix ActionResponse return introduced with Nova > 4.24.0

### DIFF
--- a/src/Actions/MockActionResponse.php
+++ b/src/Actions/MockActionResponse.php
@@ -92,6 +92,17 @@ class MockActionResponse
     }
 
     /**
+     * Asserts the handle response is of type "push".
+     *
+     * @param  string  $message
+     * @return $this
+     */
+    public function assertVisit(string $message = ''): self
+    {
+        return $this->assertResponseType('visit', $message);
+    }
+
+    /**
      * Asserts the handle response is of type "openInNewTab".
      *
      * @param  string  $message

--- a/src/Actions/MockActionResponse.php
+++ b/src/Actions/MockActionResponse.php
@@ -3,7 +3,9 @@
 namespace JoshGaber\NovaUnit\Actions;
 
 use JoshGaber\NovaUnit\Constraints\IsActionResponseType;
+use Laravel\Nova\Actions\ActionResponse;
 use PHPUnit\Framework\Assert as PHPUnit;
+use PHPUnit\Framework\Constraint\IsInstanceOf;
 use PHPUnit\Framework\Constraint\IsType;
 
 class MockActionResponse
@@ -27,8 +29,10 @@ class MockActionResponse
         PHPUnit::assertThat(
             $this->response,
             PHPUnit::logicalAnd(
-                new IsType('array'),
-                new IsActionResponseType($type)
+                is_array($this->response)
+                    ? new IsType('array')
+                    : new IsInstanceOf(ActionResponse::class),
+                new IsActionResponseType($type, $this->response)
             ),
             $message
         );

--- a/src/Actions/MockActionResponse.php
+++ b/src/Actions/MockActionResponse.php
@@ -96,7 +96,7 @@ class MockActionResponse
     }
 
     /**
-     * Asserts the handle response is of type "push".
+     * Asserts the handle response is of type "visit".
      *
      * @param  string  $message
      * @return $this

--- a/src/Constraints/IsActionResponseType.php
+++ b/src/Constraints/IsActionResponseType.php
@@ -7,10 +7,12 @@ use PHPUnit\Framework\Constraint\Constraint;
 
 class IsActionResponseType extends Constraint
 {
+    private $actionResponse;
     private $actionType;
 
-    public function __construct($actionType)
+    public function __construct($actionType, $actionResponse)
     {
+        $this->actionResponse = $actionResponse;
         $this->actionType = $actionType;
     }
 
@@ -24,12 +26,16 @@ class IsActionResponseType extends Constraint
 
     public function matches($response): bool
     {
-        $structure = \array_keys(\call_user_func([Action::class, $this->actionType], 'param 1', 'param 2'));
-        $responseKeys = \array_keys($response);
+        if (is_array($this->actionResponse)){
+            $structure = \array_keys(\call_user_func([Action::class, $this->actionType], 'param 1', 'param 2'));
+            $responseKeys = \array_keys($response);
 
-        \sort($structure);
-        \sort($responseKeys);
+            \sort($structure);
+            \sort($responseKeys);
 
-        return $structure === $responseKeys;
+            return $structure === $responseKeys;
+        }
+
+        return $this->actionResponse->offsetExists($this->actionType);
     }
 }

--- a/tests/Feature/Actions/MockActionResponseTest.php
+++ b/tests/Feature/Actions/MockActionResponseTest.php
@@ -73,6 +73,19 @@ class MockActionResponseTest extends TestCase
         $mockActionResponse->assertPush();
     }
 
+    public function testItSucceedsOnVisitResponse()
+    {
+        $mockActionResponse = new MockActionResponse(Action::visit('test'));
+        $mockActionResponse->assertVisit();
+    }
+
+    public function testItFailsOnResponseOtherThanVisit()
+    {
+        $this->shouldFail();
+        $mockActionResponse = new MockActionResponse(Action::message('test'));
+        $mockActionResponse->assertVisit();
+    }
+
     public function testItSucceedsOnDownloadResponse()
     {
         $mockActionResponse = new MockActionResponse(Action::download('test', 'test'));


### PR DESCRIPTION
Hello,

Nova 4.24.0 and up introduced a new `ActionResponse` class as return statement.

NovaUnit `MockActionResponse` expect an array instead of ActionResponse class.

This PR handle both types.