### PR TITLE
Add type assertion and expose component

### DIFF
--- a/src/Fields/InvalidFieldTypeException.php
+++ b/src/Fields/InvalidFieldTypeException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace JoshGaber\NovaUnit\Fields;
+
+/**
+ * Thrown when a provided value is not a valid Nova field type.
+ */
+class InvalidFieldTypeException extends \Exception
+{
+}

--- a/src/Fields/MockFieldElement.php
+++ b/src/Fields/MockFieldElement.php
@@ -4,6 +4,7 @@ namespace JoshGaber\NovaUnit\Fields;
 
 use Laravel\Nova\Fields\Field;
 use PHPUnit\Framework\Assert as PHPUnit;
+use PHPUnit\Framework\UnknownClassOrInterfaceException;
 
 class MockFieldElement
 {
@@ -287,6 +288,25 @@ class MockFieldElement
     {
         PHPUnit::assertFalse($this->field->sortable, $message);
 
+        return $this;
+    }
+
+    /**
+     * Assert that this field as the given field type.
+     *
+     * @param  string  $type  The Nova field type to check against
+     * @param  string  $message
+     *
+     * @return $this
+     * @throws \JoshGaber\NovaUnit\Fields\InvalidFieldTypeException
+     */
+    public function assertHasFieldType(string $type, string $message = ''): self
+    {
+        try {
+            PHPUnit::assertInstanceOf($type, $this->field);
+        } catch (UnknownClassOrInterfaceException $exception) {
+            throw new InvalidFieldTypeException("Given type $type is unknown.");
+        }
         return $this;
     }
 }

--- a/src/Fields/MockFieldElement.php
+++ b/src/Fields/MockFieldElement.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\UnknownClassOrInterfaceException;
 
 class MockFieldElement
 {
-    private $field;
+    public $field;
 
     public function __construct(Field $field)
     {

--- a/src/MockComponent.php
+++ b/src/MockComponent.php
@@ -4,7 +4,7 @@ namespace JoshGaber\NovaUnit;
 
 abstract class MockComponent
 {
-    protected $component;
+    public $component;
 
     public function __construct($component)
     {

--- a/tests/Feature/Fields/MockFieldElementTest.php
+++ b/tests/Feature/Fields/MockFieldElementTest.php
@@ -2,10 +2,12 @@
 
 namespace JoshGaber\NovaUnit\Tests\Feature\Fields;
 
+use JoshGaber\NovaUnit\Fields\InvalidFieldTypeException;
 use JoshGaber\NovaUnit\Resources\MockResource;
 use JoshGaber\NovaUnit\Tests\Fixtures\MockModel;
 use JoshGaber\NovaUnit\Tests\Fixtures\Resources\ResourceForFieldTests;
 use JoshGaber\NovaUnit\Tests\TestCase;
+use Laravel\Nova\Fields\Number;
 
 class MockFieldElementTest extends TestCase
 {
@@ -247,6 +249,25 @@ class MockFieldElementTest extends TestCase
     public function testItFailsIfFieldIsNotNotSortable()
     {
         $this->shouldFail()->mock->field('Delta')->assertNotSortable();
+    }
+
+    // endregion
+
+    // region assertHasFieldType
+    public function testItSucceedsIfFieldHasType()
+    {
+        $this->mock->field('Beta')->assertHasFieldType(Number::class);
+    }
+
+    public function testItFailsIfFieldDoesNotHaveType()
+    {
+        $this->shouldFail()->mock->field('Delta')->assertHasFieldType(Number::class);
+    }
+
+    public function testItThrowsOnInvalidFieldType()
+    {
+        $this->expectException(InvalidFieldTypeException::class);
+        $this->mock->field('Delta')->assertHasFieldType('invalid');
     }
 
     // endregion


### PR DESCRIPTION
Hi @joshgaber, thanks for this handy helper package. I came across the use-case to assert that the defined field has the given Nova field type. Useful e.g. to assert that an E-mail is rendered with the dedicated `Laravel\Nova\Fields\Email` component instead of a generic `Text` component.

I've added tests for the new method, as well as an `InvalidFieldTypeException` to have a nicer error message if the assertion receives an invalid class-string.

I also think that publicly exposing `MockComponent::$component` might come in handy for cases where we want to perform custom assertions on the actual component rather than the MockComponent. If access is restricted for a reason, I can drop those from the PR.